### PR TITLE
Add the ability to track errors (exits)

### DIFF
--- a/include/ltest-records.lfe
+++ b/include/ltest-records.lfe
@@ -3,6 +3,7 @@
   test-type
   (ok 0)
   (fail 0)
+  (err 0)
   (skip 0)
   (cancel 0)
   (time 0))

--- a/resources/make/common.mk
+++ b/resources/make/common.mk
@@ -56,10 +56,6 @@ get-codepath:
 
 debug: get-erllibs get-codepath
 
-$(EXPM): $(BIN_DIR)
-	@[ -f $(EXPM) ] || \
-	PATH=$(SCRIPT_PATH) lfetool install expm $(BIN_DIR)
-
 get-deps:
 	@echo "Getting dependencies ..."
 	@PATH=$(SCRIPT_PATH) ERL_LIBS=$(ERL_LIBS) $(LFETOOL) download deps

--- a/src/ltest-listener.lfe
+++ b/src/ltest-listener.lfe
@@ -2,6 +2,7 @@
   (behaviour eunit_listener)
   (export all))
 
+(include-lib "lutil/include/core.lfe")
 (include-lib "ltest/include/ltest-records.lfe")
 
 (defun start ()
@@ -53,11 +54,16 @@
   (('test (= `(,_ #(status #(error #(error ,error ,where))) ,_ ,_ ,_ ,_ ,_) data) state)
     (ltest-formatter:fail error where)
     (set-state-fail state (+ 1 (state-fail state))))
+  (('test (= `(,_ #(status #(error #(exit ,error ,where))) ,_ ,_ ,_ ,_ ,_) data) state)
+    (ltest-formatter:err
+      (element 2 (proplists:get_value 'status data)) where)
+    ;; XXX maybe change this to set-state-cancel?
+    (set-state-err state (+ 1 (state-err state))))
   (('test `(,_ #(status ok) ,_ ,_ ,_ ,_ ,_) state)
     (ltest-formatter:ok)
     (set-state-ok state (+ 1 (state-ok state))))
   (('test data state)
-    (io:format "\tending test ...~n")
+    (io:format "\tltest ERROR: unhandled state!~n")
     (io:format "\t\tdata: ~p~n" `(,data))
     (io:format "\t\tstate: ~p~n" `(,state))
     state))


### PR DESCRIPTION
Test failures are reported as errors of a particular type. Until now, processes exiting abnormally weren't counted in the test runner. This change adds a new field in the record for tracking errors, and then reports them afterward.