### PR TITLE
Add postfix * macros

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
 language: erlang
+install: true
 before_script:
-  - "make get-lfetool"
-  - "make copy-appsrc"
-script:
-  - "make check-travis"
-notifications:
-  irc: "irc.freenode.org#cogitat"
-  recipients:
-    - duncan@cogitat.io
+    - wget https://s3.amazonaws.com/rebar3/rebar3
+    - chmod +x rebar3
+env:
+  - PATH=".:$PATH"
+script: rebar3 eunit
 otp_release:
-  - 17.4
-  - R16B03
+  - 18.2
+  - 17.5
+  - R16B03-1
   - R15B03

--- a/include/ltest-macros.lfe
+++ b/include/ltest-macros.lfe
@@ -135,7 +135,7 @@ is thrown, an informative exception will be generated.
 
 (defmacro is-not-exception (expected-class expected-term expression)
   "The inverse case of [[is-exception/3]], for convenience."
-  `(not (is-exception ,expected-class ,expected-term ,expression)))
+  `(assertNotException ,expected-class ,expected-term ,expression))
 
 (defmacro is-error (error body)
   "Equivalent to [[is-exception/3]] with `'error` as `expected-class`."
@@ -193,6 +193,10 @@ is thrown, an informative exception will be generated.
 (defmacro is-exception* (expected-class expected-term expression)
   "Return a test object that wraps [[is-exception/3]]."
   `(_assertException ,expected-class ,expected-term ,expression))
+
+(defmacro is-not-exception* (expected-class expected-term expression)
+  "The inverse case of [[is-exception*/3]], for convenience."
+  `(_assertNotException ,expected-class ,expected-term ,expression))
 
 (defmacro is-error* (error body)
   "Return a test object that wraps [[is-error/2]]."

--- a/include/ltest-macros.lfe
+++ b/include/ltest-macros.lfe
@@ -143,7 +143,7 @@ is that it produces more detailed error messages."
   "The inverse case of [[is-equal/2]], for convenience."
   `(assertNotEqual ,value ,expression))
 
-(defmacro is-exception (expected-class expected-term expression)
+(defmacro is-exception
   "Evaluate `expression`, catching any exception and testing that it matches
 `` `#(,expected-class ,expected-term) ``. If the match fails, or if no exception
 is thrown, an informative exception will be generated.
@@ -151,35 +151,53 @@ is thrown, an informative exception will be generated.
 [[is-error/2]], [[is-exit/2]] and [[is-throw/2]] are equivalent to using
 [[is-exception/3]] with an `expected-class` of `'error`, `'exit`, or
 `'throw`, respectively."
-  `(assertException ,expected-class ,expected-term ,expression))
+  ([expression]
+   `(is-exception _ _ ,expression))
+  ([expected-class expected-term expression]
+   `(assertException ,expected-class ,expected-term ,expression)))
 
-(defmacro is-not-exception (expected-class expected-term expression)
+(defmacro is-not-exception
   "The inverse case of [[is-exception/3]], for convenience."
-  `(assertNotException ,expected-class ,expected-term ,expression))
+  ([expression]
+   `(is-not-exception _ _ ,expression))
+  ([expected-class expected-term expression]
+   `(assertNotException ,expected-class ,expected-term ,expression)))
 
-(defmacro is-error (error body)
+(defmacro is-error
   "Equivalent to [[is-exception/3]] with `'error` as `expected-class`."
-  `(assertError ,error ,body))
+  ([expression] `(is-error _ ,expression))
+  ([error body] `(assertError ,error ,body)))
 
-(defmacro is-not-error (expected-term expression)
+(defmacro is-not-error
   "The inverse case of [[is-error/2]], for convenience."
-  `(is-not-exception 'error ,expected-term ,expression))
+  ([expression]
+   `(is-not-error _ ,expression))
+  ([expected-term expression]
+   `(is-not-exception 'error ,expected-term ,expression)))
 
-(defmacro is-exit (expected-term expression)
+(defmacro is-exit
   "Equivalent to [[is-exception/3]] with `'exit` as `expected-class`."
-  `(assertExit ,expected-term ,expression))
+  ([expression]               `(is-exit _ ,expression))
+  ([expected-term expression] `(assertExit ,expected-term ,expression)))
 
-(defmacro is-not-exit (expected-term expression)
+(defmacro is-not-exit
   "The inverse case of [[is-exit/2]], for convenience."
-  `(is-not-exception 'exit ,expected-term ,expression))
+  ([expression]
+   `(is-not-exit _ ,expression))
+  ([expected-term expression]
+   `(is-not-exception 'exit ,expected-term ,expression)))
 
-(defmacro is-throw (expected-term expression)
+(defmacro is-throw
   "Equivalent to [[is-exception/3]] with `'throw` as `expected-class`."
-  `(assertThrow ,expected-term ,expression))
+  ([expression]               `(is-throw _ ,expression))
+  ([expected-term expression] `(assertThrow ,expected-term ,expression)))
 
-(defmacro is-not-throw (expected-term expression)
+(defmacro is-not-throw
   "The inverse case of [[is-throw/2]], for convenience."
-  `(is-not-exception 'throw ,expected-term ,expression))
+  ([expression]
+   `(is-not-throw _ ,expression))
+  ([expected-term expression]
+   `(is-not-exception 'throw ,expected-term ,expression)))
 
 
 ;;;===================================================================
@@ -210,34 +228,48 @@ is thrown, an informative exception will be generated.
   "Return a test object to assert `expression` evaluates to `value`."
   `(_assertNotEqual ,value ,expression))
 
-(defmacro is-exception* (expected-class expected-term expression)
+(defmacro is-exception*
   "Return a test object that wraps [[is-exception/3]]."
-  `(_assertException ,expected-class ,expected-term ,expression))
+  ([expression]
+   `(is-exception* _ _ ,expression))
+  ([expected-class expected-term expression]
+   `(_assertException ,expected-class ,expected-term ,expression)))
 
-(defmacro is-not-exception* (expected-class expected-term expression)
+(defmacro is-not-exception*
   "The inverse case of [[is-exception*/3]], for convenience."
-  `(_assertNotException ,expected-class ,expected-term ,expression))
+  ([expression]
+   `(is-not-exception* _ _ ,expression))
+  ([expected-class expected-term expression]
+   `(_assertNotException ,expected-class ,expected-term ,expression)))
 
-(defmacro is-error* (error body)
+(defmacro is-error*
   "Return a test object that wraps [[is-error/2]]."
-  `(_assertError ,error ,body))
+  ([expression] `(is-error* _ ,expression))
+  ([error body] `(_assertError ,error ,body)))
 
-(defmacro is-not-error* (error body)
+(defmacro is-not-error*
   "Return a test object that wraps [[is-not-error/2]]."
-  `(_test (is-not-error ,error ,body)))
+  ([expression] `(is-not-error* _ ,expression))
+  ([error body] `(_test (is-not-error ,error ,body))))
 
-(defmacro is-exit* (expected-term expression)
+(defmacro is-exit*
   "Return a test object that wraps [[is-exit/2]]"
-  `(_assertExit ,expected-term ,expression))
+  ([expression]               `(is-exit* _ ,expression))
+  ([expected-term expression] `(_assertExit ,expected-term ,expression)))
 
 (defmacro is-not-exit* (expected-term expression)
   "Return a test object that wraps [[is-not-exit/2]]."
-  `(_test (is-not-exit ,expected-term ,expression)))
+  ([expression]         `(is-not-exit* _ ,expression))
+  ([expected-term body] `(_test (is-not-exit ,expected-term ,expression))))
 
 (defmacro is-throw* (expected-term expression)
   "Return a test object that wraps [[is-throw/2]]."
-  `(_assertThrow ,expected-term ,expression))
+  ([expression]         `(is-throw* _ ,expression))
+  ([expected-term body] `(_assertThrow ,expected-term ,expression)))
 
 (defmacro is-not-throw* (expected-term expression)
   "Return a test object that wraps [[is-not-throw/2]]."
-  `(_test (is-not-throw 'throw ,expected-term ,expression)))
+  ([expression]
+   `(is-not-throw* _ ,expression))
+  ([expected-term body]
+   `(_test (is-not-throw 'throw ,expected-term ,expression))))

--- a/include/ltest-macros.lfe
+++ b/include/ltest-macros.lfe
@@ -1,6 +1,26 @@
 ;; Include EUnit macros
 (include-lib "eunit/include/eunit.hrl")
 
+;;;===================================================================
+;;; OTP 18 hacks
+;;;===================================================================
+
+(defmacro otp-18? () `(=:= "18" (erlang:system_info 'otp_release)))
+
+(defmacro assertion-failed () `(if (otp-18?) 'assert 'assertion_failed))
+
+(defmacro assert-equal-failed ()
+  `(if (otp-18?) 'assertEqual 'assertEqual_failed))
+
+(defmacro assert-not-equal-failed ()
+  `(if (otp-18?) 'assertNotEqual 'assertNotEqual_failed))
+
+(defmacro assert-exception-failed ()
+  `(if (otp-18?) 'assertException 'assertException_failed))
+
+(defmacro assert-match-failed ()
+  `(if (otp-18?) 'assertMatch 'assertMatch_failed))
+
 
 ;;;===================================================================
 ;;; Helper functions

--- a/include/ltest-macros.lfe
+++ b/include/ltest-macros.lfe
@@ -184,11 +184,11 @@ is thrown, an informative exception will be generated.
 
 (defmacro is-equal* (value expression)
   "Return a test object to assert `expression` evaluates to `value`."
-  `(_assertEqual ,bool-expression))
+  `(_assertEqual ,value ,expression))
 
 (defmacro is-not-equal* (value expression)
   "Return a test object to assert `expression` evaluates to `value`."
-  `(_assertNotEqual ,bool-expression))
+  `(_assertNotEqual ,value ,expression))
 
 (defmacro is-exception* (expected-class expected-term expression)
   "Return a test object that wraps [[is-exception/3]]."

--- a/include/ltest-macros.lfe
+++ b/include/ltest-macros.lfe
@@ -5,21 +5,20 @@
 ;;; OTP 18 hacks
 ;;;===================================================================
 
-(defmacro otp-18? () `(=:= "18" (erlang:system_info 'otp_release)))
+(defun otp-18? () (=:= "18" (erlang:system_info 'otp_release)))
 
-(defmacro assertion-failed () `(if (otp-18?) 'assert 'assertion_failed))
+(defun assertion-failed () (if (otp-18?) 'assert 'assertion_failed))
 
-(defmacro assert-equal-failed ()
-  `(if (otp-18?) 'assertEqual 'assertEqual_failed))
+(defun assert-equal-failed () (if (otp-18?) 'assertEqual 'assertEqual_failed))
 
-(defmacro assert-not-equal-failed ()
-  `(if (otp-18?) 'assertNotEqual 'assertNotEqual_failed))
+(defun assert-not-equal-failed ()
+  (if (otp-18?) 'assertNotEqual 'assertNotEqual_failed))
 
-(defmacro assert-exception-failed ()
-  `(if (otp-18?) 'assertException 'assertException_failed))
+(defun assert-exception-failed ()
+  (if (otp-18?) 'assertException 'assertException_failed))
 
 (defmacro assert-match-failed ()
-  `(if (otp-18?) 'assertMatch 'assertMatch_failed))
+  (if (otp-18?) 'assertMatch 'assertMatch_failed))
 
 
 ;;;===================================================================

--- a/include/ltest-macros.lfe
+++ b/include/ltest-macros.lfe
@@ -72,68 +72,72 @@
          `(lambda (x)
             (,(list_to_atom (++ (to-unders (car funcs)) "_test_case")) x)))))
 
+
+;;;===================================================================
+;;; Assertion macros
+;;;===================================================================
+
 (defmacro is (bool-expression)
-  "This macro takes an expression that returns a boolean value. If the
-  expression does not evaluate as a truth value, an error is returned."
+  "Assert `bool-expression` evaluates to `'true`."
   `(assert ,bool-expression))
 
 (defmacro is-not (bool-expression)
-  "This macro takes an expression that returns a boolean value. If the
-  expression does not evaluate as false value, an error is returned."
+  "Assert `bool-expression` evaluates to `'false`."
   `(assertNot ,bool-expression))
 
+(defmacro is-match (guard expression)
+  "Assert `guard` matches `expression`.
+
+The main reason to use [[is-match/2]], instead of matching with `=`,
+is that it produces more detailed error messages."
+  `(assertMatch ,guard ,expression))
+
+(defmacro is-not-match (guard expression)
+  "The inverse case of [[is-match/2]], for convenience."
+  `(assertNotMatch ,guard ,expression))
+
 (defmacro is-equal (value expression)
-  "This macro checks the equality between a passed value and a quoated
-  expression."
+  "Assert `expression` evaluates to `value`."
   `(assertEqual ,value ,expression))
 
 (defmacro is-not-equal (value expression)
-  "This macro checks the inequality between an expected value and a passed
-  expression."
+  "The inverse case of [[is-equal/2]], for convenience."
   `(assertNotEqual ,value ,expression))
 
 (defmacro is-exception (expected-class expected-term expression)
-  "This macro check that the passeed expression raises the expected
-  exception class (e.g., 'error, 'throw, etc.) and term (e.g., 'undef,
-  'badarith, etc.)."
+  "Evaluate `expression`, catching any exception and testing that it matches
+`` `#(,expected-class ,expected-term) ``. If the match fails, or if no exception
+is thrown, an informative exception will be generated.
+
+[[is-error/2]], [[is-exit/2]] and [[is-throw/2]] are equivalent to using
+[[is-exception/3]] with an `expected-class` of `'error`, `'exit`, or
+`'throw`, respectively."
   `(assertException ,expected-class ,expected-term ,expression))
 
 (defmacro is-not-exception (expected-class expected-term expression)
-  "This macro check that the passeed expression does not raise the expected
-  exception class (e.g., 'error, 'throw, etc.) and term (e.g., 'undef,
-  'badarith, etc.)."
+  "The inverse case of [[is-exception/3]], for convenience."
   `(not (is-exception ,expected-class ,expected-term ,expression)))
 
 (defmacro is-error (error body)
-  "This macro is a convenience macro for is-exception with an
-  exception class of 'error."
+  "Equivalent to [[is-exception/3]] with `'error` as `expected-class`."
   `(assertError ,error ,body))
 
 (defmacro is-not-error (expected-term expression)
-  "This macro is a convenience macro for is-not-exception with an
-  exception class of 'error."
+  "The inverse case of [[is-error/2]], for convenience."
   `(is-not-exception 'error ,expected-term ,expression))
 
 (defmacro is-exit (expected-term expression)
-  "This macro is a convenience macro for is-exception with an
-  exception class of 'exit."
+  "Equivalent to [[is-exception/3]] with `'exit` as `expected-class`."
   `(assertExit ,expected-term ,expression))
 
 (defmacro is-not-exit (expected-term expression)
-  "This macro is a convenience macro for is-not-exception with an
-  exception class of 'exit."
+  "The inverse case of [[is-exit/2]], for convenience."
   `(is-not-exception 'exit ,expected-term ,expression))
 
 (defmacro is-throw (expected-term expression)
-  "This macro is a convenience macro for is-exception with an
-  exception class of 'throw."
+  "Equivalent to [[is-exception/3]] with `'throw` as `expected-class`."
   `(assertThrow ,expected-term ,expression))
 
 (defmacro is-not-throw (expected-term expression)
-  "This macro is a convenience macro for is-not-exception with an
-  exception class of 'throw."
+  "The inverse case of [[is-throw/2]], for convenience."
   `(is-not-exception 'throw ,expected-term ,expression))
-
-(defmacro is-match (guard expression)
-  ""
-  `(assertMatch ,guard ,expression))

--- a/include/ltest-macros.lfe
+++ b/include/ltest-macros.lfe
@@ -160,3 +160,60 @@ is thrown, an informative exception will be generated.
 (defmacro is-not-throw (expected-term expression)
   "The inverse case of [[is-throw/2]], for convenience."
   `(is-not-exception 'throw ,expected-term ,expression))
+
+
+;;;===================================================================
+;;; Test object macros
+;;;===================================================================
+
+(defmacro is* (bool-expression)
+  "Return a test object that wraps [[is/1]]."
+  `(_assert ,bool-expression))
+
+(defmacro is-not* (bool-expression)
+  "Return a test object that wraps [[is-not/2]]."
+  `(_assertNot ,bool-expression))
+
+(defmacro is-match* (guard expression)
+  "Return a test object that wraps [[is-match/2]]."
+  `(_assertMatch ,guard ,expression))
+
+(defmacro is-not-match* (guard expression)
+  "The inverse case of [[is-match*/2]], for convenience."
+  `(_assertMatch ,guard ,expression))
+
+(defmacro is-equal* (value expression)
+  "Return a test object to assert `expression` evaluates to `value`."
+  `(_assertEqual ,bool-expression))
+
+(defmacro is-not-equal* (value expression)
+  "Return a test object to assert `expression` evaluates to `value`."
+  `(_assertNotEqual ,bool-expression))
+
+(defmacro is-exception* (expected-class expected-term expression)
+  "Return a test object that wraps [[is-exception/3]]."
+  `(_assertException ,expected-class ,expected-term ,expression))
+
+(defmacro is-error* (error body)
+  "Return a test object that wraps [[is-error/2]]."
+  `(_assertError ,error ,body))
+
+(defmacro is-not-error* (error body)
+  "Return a test object that wraps [[is-not-error/2]]."
+  `(_test (is-not-error ,error ,body)))
+
+(defmacro is-exit* (expected-term expression)
+  "Return a test object that wraps [[is-exit/2]]"
+  `(_assertExit ,expected-term ,expression))
+
+(defmacro is-not-exit* (expected-term expression)
+  "Return a test object that wraps [[is-not-exit/2]]."
+  `(_test (is-not-exit ,expected-term ,expression)))
+
+(defmacro is-throw* (expected-term expression)
+  "Return a test object that wraps [[is-throw/2]]."
+  `(_assertThrow ,expected-term ,expression))
+
+(defmacro is-not-throw* (expected-term expression)
+  "Return a test object that wraps [[is-not-throw/2]]."
+  `(_test (is-not-throw 'throw ,expected-term ,expression)))

--- a/include/ltest-macros.lfe
+++ b/include/ltest-macros.lfe
@@ -1,13 +1,19 @@
+;; Include EUnit macros
 (include-lib "eunit/include/eunit.hrl")
+
+
+;;;===================================================================
+;;; Helper functions
+;;;===================================================================
 
 (eval-when-compile
   (defun to-unders (atm)
     (re:replace (atom_to_list atm) "-" "_" '(#(return list) global)))
   (defun list-body
-    ((body) (when (is_list body))
-      body)
-    ((body)
-      (list body)))
+    ([body] (when (is_list body))
+     body)
+    ([body]
+     (list body)))
   ;; end of eval-when-compile
   )
 

--- a/include/ltest-macros.lfe
+++ b/include/ltest-macros.lfe
@@ -17,27 +17,30 @@
   ;; end of eval-when-compile
   )
 
-(defmacro deftest arg
-  "This macro is for defining standard EUnit tests."
-  (let ((name (car arg))
-        (body (cdr arg)))
-    `(defun ,(list_to_atom (++ (atom_to_list name) "_test")) ()
-       ,@body)))
 
-(defmacro deftestgen arg
-  "This macro is for defining EUnit tests that use test generators."
-  (let ((name (to-unders (car arg)))
-        (body (cdr arg)))
-    `(defun ,(list_to_atom (++ name "_test_")) ()
-       ,@body)))
+;;;===================================================================
+;;; Test definition macros
+;;;===================================================================
 
-(defmacro deftestskip arg
-  "This macro is for defining standard EUnit test that will be skipped (not
-  run)."
-  (let ((name (car arg))
-        (body (cdr arg)))
-    `(defun ,(list_to_atom (++ (atom_to_list name) "_skip")) ()
-       ,@body)))
+(defmacro deftest
+  "Define a standard EUnit test."
+  ([name . body]
+   `(defun ,(list_to_atom (++ (to-unders name) "_test")) ()
+      ,@body)))
+
+(defmacro deftestgen
+  "Define an EUnit test that uses test generators."
+  ([name . body]
+   `(defun ,(list_to_atom (++ (to-unders name) "_test_")) ()
+      ,@body)))
+
+(defmacro deftestskip
+  "Define a standard EUnit test that will be skipped (not run)."
+  ([name . body]
+   `(defun ,(list_to_atom (++ (to-unders name) "_skip")) ()
+      ,@body)))
+
+
 
 (defmacro defsetup (func-name)
   "A simple wrapper macro for defining the set-up function in a fixture."

--- a/include/ltest-macros.lfe
+++ b/include/ltest-macros.lfe
@@ -5,20 +5,21 @@
 ;;; OTP 18 hacks
 ;;;===================================================================
 
-(defun otp-18? () (=:= "18" (erlang:system_info 'otp_release)))
+(defmacro otp-18? () `(=:= "18" (erlang:system_info 'otp_release)))
 
-(defun assertion-failed () (if (otp-18?) 'assert 'assertion_failed))
+(defmacro assertion-failed () `(if (otp-18?) 'assert 'assertion_failed))
 
-(defun assert-equal-failed () (if (otp-18?) 'assertEqual 'assertEqual_failed))
+(defmacro assert-equal-failed ()
+  `(if (otp-18?) 'assertEqual 'assertEqual_failed))
 
-(defun assert-not-equal-failed ()
-  (if (otp-18?) 'assertNotEqual 'assertNotEqual_failed))
+(defmacro assert-not-equal-failed ()
+  `(if (otp-18?) 'assertNotEqual 'assertNotEqual_failed))
 
-(defun assert-exception-failed ()
-  (if (otp-18?) 'assertException 'assertException_failed))
+(defmacro assert-exception-failed ()
+  `(if (otp-18?) 'assertException 'assertException_failed))
 
 (defmacro assert-match-failed ()
-  (if (otp-18?) 'assertMatch 'assertMatch_failed))
+  `(if (otp-18?) 'assertMatch 'assertMatch_failed))
 
 
 ;;;===================================================================

--- a/include/ltest-macros.lfe
+++ b/include/ltest-macros.lfe
@@ -41,13 +41,20 @@
       ,@body)))
 
 
+;;;===================================================================
+;;; Set-up and tear-down macros
+;;;===================================================================
 
 (defmacro defsetup (func-name)
-  "A simple wrapper macro for defining the set-up function in a fixture."
+  "Return a nullary function that calls `func-name/0`.
+
+A simple wrapper macro for defining the set-up function in a fixture."
   `(lambda () (,func-name)))
 
 (defmacro defteardown (func-name)
-  "A simple wrapper macro for defining the tear-down function in a fixture."
+  "Return a unary function that calls `func-name/1` on its argument.
+
+A simple wrapper macro for defining the tear-down function in a fixture."
   `(lambda (x) (,func-name x)))
 
 (defmacro deftestcase body

--- a/include/ltest-macros.lfe
+++ b/include/ltest-macros.lfe
@@ -57,22 +57,25 @@ A simple wrapper macro for defining the set-up function in a fixture."
 A simple wrapper macro for defining the tear-down function in a fixture."
   `(lambda (x) (,func-name x)))
 
-(defmacro deftestcase body
+
+;;;===================================================================
+;;; Test case macros
+;;;===================================================================
+
+(defmacro deftestcase
   "This macro is for defining EUnit tests for use by fixtures which have
   particular naming convention needs."
-  (let ((func-name (car body))
-        (args (cadr body))
-        (rest (cddr body)))
-  `(defun ,(list_to_atom (++ (to-unders func-name) "_test_case")) (,@args)
-    (list
-      ,@(lists:map
-        (lambda (part)
-          `(lambda () ,part))
-        rest)))))
+  ([func-name args . rest]
+   `(defun ,(list_to_atom (++ (to-unders func-name) "_test_case")) (,@args)
+      (list
+        ,@(lists:map
+            (lambda (part)
+              `(lambda () ,part))
+            rest)))))
 
 (defmacro deftestcases funcs
   "This macro expects one or more function *names* which have been defined
-  using (deftestcase ...).
+  using [[deftestcase/255]].
 
   Note that this macro is not composable with (deftestcase ...); you must
   define the test case and then only pass the test case name to this

--- a/rebar.config
+++ b/rebar.config
@@ -7,14 +7,14 @@
   ]}.
 
 {deps, [
-    {lfe, ".*", {git, "git://github.com/rvirding/lfe.git", {tag, "v1.0"}}},
-    {lutil, ".*", {git, "git://github.com/lfex/lutil.git", {tag, "0.8.0"}}},
-    {clj, ".*", {git, "git://github.com/lfex/clj.git", {tag, "0.4.0"}}},
-    {color, ".*", {git, "git://github.com/julianduque/erlang-color.git", {tag, "v0.2.0"}}}
+    {lfe, {git, "git://github.com/rvirding/lfe.git", {tag, "v1.0"}}},
+    {lutil, {git, "git://github.com/lfex/lutil.git", {tag, "0.8.0"}}},
+    {clj, {git, "git://github.com/lfex/clj.git", {tag, "0.4.0"}}},
+    {color, {git, "git://github.com/julianduque/erlang-color.git", {tag, "v0.2.0"}}}
   ]}.
 
 {plugins, [
-   {'lfe-compile', ".*", {git, "https://github.com/lfe-rebar3/compile.git", {tag, "0.3.0"}}}
+   {'lfe-compile', {git, "https://github.com/lfe-rebar3/compile.git", {tag, "0.3.0"}}}
   ]}.
 
 {provider_hooks, [

--- a/src/ltest.lfe
+++ b/src/ltest.lfe
@@ -97,6 +97,6 @@
        assert-exception when an unexpected error occurs, and
     2) checks the buried failure type against an expected value, asserting
        that they are the same."
-  (let (((tuple 'assertException_failed
-    (list _ _ _ _ (tuple fail-type _))) data))
+  (let* ((reason (assert-exception-failed))
+         (`#(,reason [,_ ,_ ,_ ,_ #(,fail-type ,_)]) data))
     (is-equal fail-type expected)))

--- a/test/ltest-basic-tests.lfe
+++ b/test/ltest-basic-tests.lfe
@@ -38,7 +38,7 @@
       (is 'false)
       (error 'unexpected-test-success))
     (catch ((tuple type value _)
-      (check-failed-assert value 'assertion_failed)))))
+      (check-failed-assert value (assertion-failed))))))
 
 (deftest is-not
   (is-not 'false)
@@ -51,7 +51,7 @@
       (is-not 'true)
       (error 'unexpected-test-success))
     (catch ((tuple type value _)
-      (check-failed-assert value 'assertion_failed)))))
+      (check-failed-assert value (assertion-failed))))))
 
 (deftest is-equal
   (is-equal 1 1)
@@ -64,7 +64,7 @@
       (is-equal 1 2)
       (error 'unexpected-test-success))
     (catch ((tuple type value _)
-      (check-failed-assert value 'assertEqual_failed)))))
+      (check-failed-assert value (assert-equal-failed))))))
 
 (deftest is-not-equal
   (is-not-equal 0 1)
@@ -77,7 +77,7 @@
       (is-not-equal 1 (+ 1 0))
       (error 'unexpected-test-success))
     (catch ((tuple type value _)
-      (check-failed-assert value 'assertNotEqual_failed)))))
+      (check-failed-assert value (assert-not-equal-failed))))))
 
 (deftest is-exception
   (is-exception 'throw 'my-error (throw 'my-error)))
@@ -189,4 +189,4 @@
       (is-match (tuple 1 'a) #(1 b))
       (error 'unexpected-test-success))
     (catch ((tuple type value _)
-      (check-failed-assert value 'assertMatch_failed)))))
+      (check-failed-assert value (assert-match-failed))))))

--- a/test/ltest-basic-tests.lfe
+++ b/test/ltest-basic-tests.lfe
@@ -107,7 +107,7 @@
       (check-wrong-assert-exception value 'unexpected_success)))))
 
 (deftest is-not-exception
-  (is-not-exception _ _ (+ 2 2)))
+  (is-not-exception (+ 2 2)))
 
 (deftest is-not-exception-exit
   (is-not-exception 'exit 'badarith (/ 1 0)))

--- a/test/ltest-basic-tests.lfe
+++ b/test/ltest-basic-tests.lfe
@@ -106,7 +106,14 @@
     (catch ((tuple type value _)
       (check-wrong-assert-exception value 'unexpected_success)))))
 
-; XXX add test: is-not-exception_test
+(deftest is-not-exception
+  (is-not-exception _ _ (+ 2 2)))
+
+(deftest is-not-exception-exit
+  (is-not-exception 'exit 'badarith (/ 1 0)))
+
+(deftest is-not-exception-throw
+  (is-not-exception 'throw 'badarith (/ 1 0)))
 
 (deftest is-error
   (is-error 'badarith (/ 1 0)))
@@ -176,11 +183,10 @@
   (is-match (tuple 1 'a) #(1 a))
   (is-match (tuple 1 (tuple 2 'pull)) #(1 #(2 pull))))
 
-; XXX add test: is-match-fail_test
 (deftest is-match-fail
   (try
     (progn
       (is-match (tuple 1 'a) #(1 b))
-      (: erlang error 'unexpected-test-success))
+      (error 'unexpected-test-success))
     (catch ((tuple type value _)
       (check-failed-assert value 'assertMatch_failed)))))

--- a/test/ltest-fixture-tests.lfe
+++ b/test/ltest-fixture-tests.lfe
@@ -1,10 +1,6 @@
 (defmodule ltest-fixture-tests
   (behaviour ltest-unit)
-  (export all)
-  (import
-    (from ltest
-      (check-failed-assert 2)
-      (check-wrong-assert-exception 2))))
+  (export all))
 
 (include-lib "include/ltest-macros.lfe")
 

--- a/test/ltest-fixture-tests.lfe
+++ b/test/ltest-fixture-tests.lfe
@@ -4,60 +4,34 @@
 
 (include-lib "include/ltest-macros.lfe")
 
-(defun set-up ()
-  'ok)
+(defun set-up () 'ok)
 
-(defun tear-down (set-up-result)
-  (is-equal set-up-result 'ok))
+(defun tear-down (set-up-result) (is-equal set-up-result 'ok))
 
 (defun setup_test_case (set-up-result)
   "This is called the 'Instantiator' in EUnit parlance."
-  (list
-    (lambda ()
-      (is-equal set-up-result 'ok))
-    (lambda ()
-      (is-not-equal 'this-test 'very-silly))))
+  `[,(is-equal* set-up-result 'ok)
+    ,(is-not-equal* 'this-test 'very-silly)])
 
 (defun foreach_test_case (set-up-result)
   "This is called the 'Instantiator' in EUnit parlance."
-  (list
-    (lambda ()
-      (is-equal set-up-result 'ok))
-    (lambda ()
-      (is-not-equal 'this-test 'very-silly))))
+  `[,(is-equal* set-up-result 'ok)
+    ,(is-not-equal* 'this-test 'very-silly)])
 
-(deftestgen setup-setup
-  (tuple
-    'setup
-    (lambda () (set-up))
-    (lambda (x) (setup_test_case x))))
+(deftestgen setup-setup `#(setup ,(defsetup set-up) ,#'setup_test_case/1))
 
 (deftestgen setup-setup-cleanup
-  (tuple
-    'setup
-    (lambda () (set-up))
-    (lambda (x) (tear-down x))
-    (lambda (x) (setup_test_case x))))
+  `#(setup ,(defsetup set-up) ,(defteardown tear-down) ,#'setup_test_case/1))
 
 ; XXX add a test for setup-where-setup
 ; XXX add a test for setup-where-setup-cleanup
 
 (deftestgen foreach-setup
-  (tuple
-    'foreach
-    (lambda () (set-up))
-    (list
-      (lambda (x) (setup_test_case x))
-      (lambda (x) (foreach_test_case x)))))
+  `#(foreach ,(defsetup set-up) [,#'setup_test_case/1 ,#'foreach_test_case/1]))
 
 (deftestgen foreach-setup-cleanup
-  (tuple
-    'foreach
-    (lambda () (set-up))
-    (lambda (x) (tear-down x))
-    (list
-      (lambda (x) (setup_test_case x))
-      (lambda (x) (foreach_test_case x)))))
+  `#(foreach ,(defsetup set-up) ,(defteardown tear-down)
+             [,#'setup_test_case/1 ,#'foreach_test_case/1]))
 
 ; XXX add a test for foreach-where-setup
 ; XXX add a test for foreach-where-setup-cleanup

--- a/test/ltest-fixturecase-tests.lfe
+++ b/test/ltest-fixturecase-tests.lfe
@@ -4,11 +4,9 @@
 
 (include-lib "include/ltest-macros.lfe")
 
-(defun set-up ()
-  'ok)
+(defun set-up () 'ok)
 
-(defun tear-down (set-up-result)
-  (is-equal set-up-result 'ok))
+(defun tear-down (set-up-result) (is-equal set-up-result 'ok))
 
 (deftestcase setup-tc (set-up-result)
   ;; This is called the 'Instantiator' in EUnit parlance.
@@ -20,40 +18,25 @@
   (is-equal set-up-result 'ok)
   (is-not-equal 'this-test 'very-silly))
 
-(deftestgen setup-setup
-  (tuple
-    'setup
-    (defsetup set-up)
-    (deftestcases
-      setup-tc)))
+(deftestgen setup-setup `#(setup ,(defsetup set-up) ,(deftestcases setup-tc)))
 
 (deftestgen setup-setup-cleanup
-  (tuple
-    'setup
-    (defsetup set-up)
-    (defteardown tear-down)
-    (deftestcases
-      setup-tc)))
+  `#(setup
+     ,(defsetup set-up)
+     ,(defteardown tear-down)
+     ,(deftestcases setup-tc)))
 
 ; XXX add a test for setup-where-setup
 ; XXX add a test for setup-where-setup-cleanup
 
 (deftestgen foreach-setup
-  (tuple
-    'foreach
-    (defsetup set-up)
-    (deftestcases
-      setup-tc
-      foreach-tc)))
+  `#(foreach ,(defsetup set-up) ,(deftestcases setup-tc foreach-tc)))
 
 (deftestgen foreach-setup-cleanup
-  (tuple
-    'foreach
-    (defsetup set-up)
-    (defteardown tear-down)
-    (deftestcases
-      setup-tc
-      foreach-tc)))
+  `#(foreach
+     ,(defsetup set-up)
+     ,(defteardown tear-down)
+     ,(deftestcases setup-tc foreach-tc)))
 
 ; XXX add a test for foreach-where-setup
 ; XXX add a test for foreach-where-setup-cleanup

--- a/test/ltest-fixturecase-tests.lfe
+++ b/test/ltest-fixturecase-tests.lfe
@@ -1,10 +1,6 @@
 (defmodule ltest-fixturecase-tests
   (behaviour ltest-unit)
-  (export all)
-  (import
-    (from ltest
-      (check-failed-assert 2)
-      (check-wrong-assert-exception 2))))
+  (export all))
 
 (include-lib "include/ltest-macros.lfe")
 

--- a/test/ltest-generated-tests.lfe
+++ b/test/ltest-generated-tests.lfe
@@ -1,10 +1,6 @@
 (defmodule ltest-generated-tests
   (behaviour ltest-unit)
-  (export all)
-  (import
-    (from ltest
-      (check-failed-assert 2)
-      (check-wrong-assert-exception 2))))
+  (export all))
 
 (include-lib "include/ltest-macros.lfe")
 

--- a/test/ltest-generated-tests.lfe
+++ b/test/ltest-generated-tests.lfe
@@ -4,24 +4,15 @@
 
 (include-lib "include/ltest-macros.lfe")
 
-(deftestgen one-lambda
-  (lambda () (is 'true)))
+(deftestgen is* (is* 'true))
 
-(deftestgen one-lambda-in-list
-  (list
-    (lambda () (is-not 'false))))
+(deftestgen is-not*-in-list `[,(is-not* 'false)])
 
-(deftestgen many-lambdas-in-list
-  (list
-    (lambda () (is 'true))
-    (lambda () (is-not 'false))
-    (lambda () (is-equal 1 1))))
+(deftestgen many-generators-in-list
+  `[,(is* 'true) ,(is-not* 'false) ,(is-equal* 1 1)])
 
-(deftestgen lambda-with-nested-testset
-  (lambda ()
-    (list (is 'true)
-          (is-not 'false)
-          (is-equal 2 2)
-          (list (is 'true)
-                (is-not 'false)
-                (is-equal 1 1)))))
+(deftestgen nested-test-set
+  `[,(is* 'true)
+    ,(is-not* 'false)
+    ,(is-equal* 2 2)
+    [,(is* 'true) ,(is-not* 'false) ,(is-equal* 1 1)]])

--- a/test/ltest-named-tests.lfe
+++ b/test/ltest-named-tests.lfe
@@ -3,8 +3,7 @@
   (export all)
   (import
     (from ltest
-      (check-failed-assert 2)
-      (check-wrong-assert-exception 2))))
+      (check-failed-assert 2))))
 
 (include-lib "include/ltest-macros.lfe")
 

--- a/test/ltest-named-tests.lfe
+++ b/test/ltest-named-tests.lfe
@@ -20,7 +20,7 @@
         (is-not 'true)
         (error 'unexpected-test-success))
       (catch ((tuple type value _)
-        (check-failed-assert value 'assertion_failed))))))
+        (check-failed-assert value (assertion-failed)))))))
 
 (deftest named-testset-with-one
   (tuple '"Testing a named test set with one entry."
@@ -63,4 +63,5 @@
                           (error 'unexpected-test-succes))
                         (catch
                           ((tuple type value _)
-                           (check-failed-assert value 'assertEqual_failed)))))))))
+                           (check-failed-assert value
+                                                (assert-equal-failed))))))))))

--- a/test/ltest-testset-tests.lfe
+++ b/test/ltest-testset-tests.lfe
@@ -3,8 +3,7 @@
   (export all)
   (import
     (from ltest
-      (check-failed-assert 2)
-      (check-wrong-assert-exception 2))))
+      (check-failed-assert 2))))
 
 (include-lib "include/ltest-macros.lfe")
 

--- a/test/ltest-testset-tests.lfe
+++ b/test/ltest-testset-tests.lfe
@@ -7,40 +7,32 @@
 
 (include-lib "include/ltest-macros.lfe")
 
-(deftest testset-with-one
-  (list (is 'true)))
+(deftest testset-with-one `[,(is 'true)])
 
-(deftest testset-with-two
-  (list (is 'true)
-        (is-not 'false)))
+(deftest testset-with-two `[,(is 'true) ,(is-not 'false)])
 
-(deftest testset-with-three
-  (list (is 'true)
-        (is-not 'false)
-        (is-equal 2 2)))
+(deftest testset-with-three `[,(is 'true) ,(is-not 'false) ,(is-equal 2 2)])
 
 (deftest testset-nested
-  (list (is 'true)
-        (is-not 'false)
-        (is-equal 2 2)
-        (list (is 'true)
-              (is-not 'false)
-              (is-equal 1 1))))
+  `[,(is 'true)
+    ,(is-not 'false)
+    ,(is-equal 2 2)
+    [,(is 'true) ,(is-not 'false) ,(is-equal 1 1)]])
 
 (deftest testset-deeply-nested
-  (list (is 'true)
-        (is-not 'false)
-        (is-equal 1 1)
-        (list (is 'true)
-              (is-not 'false)
-              (is-equal 2 2)
-              (list (is 'true)
-                    (is-not 'false)
-                    (is-equal 3 3)
-                    (try
-                      (progn
-                        (is-equal 3 4)
-                        (error 'unexpected-test-succes))
-                      (catch
-                        ((tuple type value _)
-                         (check-failed-assert value 'assertEqual_failed))))))))
+  `[,(is 'true)
+    ,(is-not 'false)
+    ,(is-equal 1 1)
+    [,(is 'true)
+     ,(is-not 'false)
+     ,(is-equal 2 2)
+     [,(is 'true)
+      ,(is-not 'false)
+      ,(is-equal 3 3)
+      ,(try
+         (progn
+           (is-equal 3 4)
+           (error 'unexpected-test-succes))
+         (catch
+           (`#(,type ,value ,_)
+            (check-failed-assert value 'assertEqual_failed))))]]])

--- a/test/ltest-testset-tests.lfe
+++ b/test/ltest-testset-tests.lfe
@@ -35,4 +35,4 @@
            (error 'unexpected-test-succes))
          (catch
            (`#(,type ,value ,_)
-            (check-failed-assert value 'assertEqual_failed))))]]])
+            (check-failed-assert value (assert-equal-failed)))))]]])


### PR DESCRIPTION
#### CHANGES ####
- Add postfix `*` macros, which are equivalent to EUnit's prefix `_` macros and update the tests accordingly.
- Convert lots of `list` and `tuple` calls to quasiquoting, for no real reason. Brevity, maybe... :wink:
- Update `.travis.yml` to use `rebar3`. N.B. `Makefile` is now unused/outdated.
- Add some hacks to allow the tests to pass on `R15B03`, `R16B03-1`, `17.5` and `18.2`. EUnit introduced a breaking change in `18.x w.r.t. how errors are handled. The added functions in `include/ltest-macros.lfe` help mitigate.
- Make the docstrings in `include/test-macros.lfe` more Lodox friendly.
- Update `rebar.config` to `rebar3` dependency syntax.
- Close #36.

#### TODO ####
- Bump and tag version.
- Delete or update `Makefile`.

#### LATER ####
- Once quasiquoting/lodox#57 is fixed, add Lodox config to `rebar.config`.