### PR TITLE
Auto-export deftest and deftestgen

### DIFF
--- a/include/ltest-macros.lfe
+++ b/include/ltest-macros.lfe
@@ -45,14 +45,16 @@
 (defmacro deftest
   "Define a standard EUnit test."
   ((name . body)
-   `(defun ,(list_to_atom (++ (to-unders name) "_test")) ()
-      ,@body)))
+   (let ((name_test (list_to_atom (++ (to-unders name) "_test"))))
+     `(progn (defun ,name_test () ,@body)
+             (extend-module (export (,name_test 0)))))))
 
 (defmacro deftestgen
   "Define an EUnit test that uses test generators."
   ((name . body)
-   `(defun ,(list_to_atom (++ (to-unders name) "_test_")) ()
-      ,@body)))
+   (let ((name_test_ (list_to_atom (++ (to-unders name) "_test_"))))
+     `(progn (defun ,name_test_ () ,@body)
+             (extend-module (export (,name_test_ 0)))))))
 
 (defmacro deftestskip
   "Define a standard EUnit test that will be skipped (not run)."

--- a/test/ltest-basic-tests.lfe
+++ b/test/ltest-basic-tests.lfe
@@ -1,6 +1,5 @@
 (defmodule ltest-basic-tests
   (behaviour ltest-unit)
-  (export all)
   (import
     (from ltest
       (check-failed-assert 2)

--- a/test/ltest-fixture-tests.lfe
+++ b/test/ltest-fixture-tests.lfe
@@ -1,6 +1,5 @@
 (defmodule ltest-fixture-tests
-  (behaviour ltest-unit)
-  (export all))
+  (behaviour ltest-unit))
 
 (include-lib "include/ltest-macros.lfe")
 


### PR DESCRIPTION
Wrap the resultant `defun` in a `progn` and add the appropriate `extend-module` call.

Remove the `(export all)` from `ltest-{basic,fixture}-tests` to test this.

Fixes #41.