### PR TITLE
Use user-defined test name in report

### DIFF
--- a/include/ltest-macros.lfe
+++ b/include/ltest-macros.lfe
@@ -88,12 +88,8 @@ A simple wrapper macro for defining the tear-down function in a fixture."
 ;;;===================================================================
 
 (eval-when-compile
-  (defun is-named-tuple (t)
-    (progn ;(lfe_io:format "~p" (list t)) ;for debugging
-           (is-named-tuple1 t)))
-
-  ;Return true if we have (tuple "name"...) or #("Name"...)
-  (defun is-named-tuple1
+  ;;Return true if we have (tuple "name"...) or #("Name"...)
+  (defun is-named-tuple
     ((t) (when (is_tuple t))
       (if (io_lib:printable_list (element 1 t))
         'true
@@ -105,7 +101,7 @@ A simple wrapper macro for defining the tear-down function in a fixture."
         'false))
     ((other) 'false))
 
-  ;Return (tuple "Name" lambda() ...) from (tuple "Name" ...)
+  ;;Return (tuple "Name" lambda() ...) from (tuple "Name" ...)
   (defun mk-named-tuple
     ((t) (when (is_tuple t))
       `(tuple ,(element 1 t)

--- a/include/ltest-macros.lfe
+++ b/include/ltest-macros.lfe
@@ -91,14 +91,10 @@ A simple wrapper macro for defining the tear-down function in a fixture."
   ;;Return true if we have (tuple "name"...) or #("Name"...)
   (defun is-named-tuple
     ((t) (when (is_tuple t))
-      (if (io_lib:printable_list (element 1 t))
-        'true
-        'false))
+      (io_lib:printable_list (element 1 t)))
     ((t) (when (is_list t))
-      (if (andalso (== 'tuple (hd t))
-                   (io_lib:printable_list (cadr t)))
-        'true
-        'false))
+      (andalso (== 'tuple (hd t))
+               (io_lib:printable_list (cadr t))))
     ((other) 'false))
 
   ;;Return (tuple "Name" lambda() ...) from (tuple "Name" ...)

--- a/priv/make/test.mk
+++ b/priv/make/test.mk
@@ -3,7 +3,7 @@ CWD := $(CURDIR)
 compile-tests:
 	@rebar3 as test do clean, compile
 
-check-runner-ltest: export CODE_PATH = _build/test/lib/*/ebin
+check-runner-ltest: export CODE_PATH = _build/test/lib/*/ebin _build/test/plugins/*/ebin
 check-runner-ltest: compile-tests
 	@clear
 	@erl -pa ${CODE_PATH} -cwd "${CWD}" -listener ltest-listener -eval \

--- a/src/ltest-formatter.lfe
+++ b/src/ltest-formatter.lfe
@@ -40,8 +40,11 @@
 (defun indent (count)
   (string:copies " " count))
 
-(defun func-line (raw-func)
-  (let ((func (get-func-name raw-func)))
+(defun func-line (raw-func desc)
+  (let ((func
+           (if (!= 'undefined desc)
+               desc
+               (get-func-name raw-func))))
     (io:format "~s~s ~s" `(,(indent (ltest-const:func-indent))
                            ,func
                            ,(get-elision func)))))
@@ -57,13 +60,17 @@
     "_test(_)?$" "" '(global #(return list))))
 
 
-(defun get-elision (func-name)
-  (let* ((init-len (+ (ltest-const:func-indent)
-                      (length func-name)))
-         (end-len (length " [fail]"))
-         (elide-len (- (ltest-const:test-suite-width)
-                       (+ init-len end-len))))
-    (string:copies "." elide-len)))
+(defun get-elision
+  ((func-name) (when (is_list func-name))
+    (let* ((init-len (+ (ltest-const:func-indent)
+                        (length func-name)))
+           (end-len (length " [fail]"))
+           (elide-len (- (ltest-const:test-suite-width)
+                         (+ init-len end-len))))
+      (string:copies "." elide-len)))
+  ;Named tests send description as binary
+  ((desc) (when (is_binary desc))
+    (get-elision (binary_to_list desc))))
 
 (defun mod-line (desc)
   (io:format "~smodule: ~s~n"

--- a/src/ltest-listener.lfe
+++ b/src/ltest-listener.lfe
@@ -25,7 +25,8 @@
     ; (io:format "\tstate: ~p~n" (list state))
     state)
   (('test (= `(,_ ,_ #(source #(,mod ,func ,arity)) ,_) data) state)
-    (ltest-formatter:func-line func)
+    (ltest-formatter:func-line func
+                               (proplists:get_value 'desc data 'undefined))
     ;(io:format "\t\tdata: ~p~n" (list data))
     ;(io:format "\t\tstate: ~p~n" (list state))
     state)

--- a/test/ltest-fixture-tests.lfe
+++ b/test/ltest-fixture-tests.lfe
@@ -10,7 +10,8 @@
 (defun setup_test_case (set-up-result)
   "This is called the 'Instantiator' in EUnit parlance."
   `[,(is-equal* set-up-result 'ok)
-    ,(tuple "Silly test" (is-not-equal* 'this-test 'very-silly))])
+     (is-not-equal* 'this-test 'very-silly)
+    ,(tuple "Named setup test" (is-not-equal* 'to-be 'or-not-to-be))])
 
 (defun foreach_test_case (set-up-result)
   "This is called the 'Instantiator' in EUnit parlance."

--- a/test/ltest-fixture-tests.lfe
+++ b/test/ltest-fixture-tests.lfe
@@ -10,7 +10,7 @@
 (defun setup_test_case (set-up-result)
   "This is called the 'Instantiator' in EUnit parlance."
   `[,(is-equal* set-up-result 'ok)
-     (is-not-equal* 'this-test 'very-silly)
+    ,(is-not-equal* 'this-test 'very-silly)
     ,(tuple "Named setup test" (is-not-equal* 'to-be 'or-not-to-be))])
 
 (defun foreach_test_case (set-up-result)

--- a/test/ltest-fixture-tests.lfe
+++ b/test/ltest-fixture-tests.lfe
@@ -10,7 +10,7 @@
 (defun setup_test_case (set-up-result)
   "This is called the 'Instantiator' in EUnit parlance."
   `[,(is-equal* set-up-result 'ok)
-    ,(is-not-equal* 'this-test 'very-silly)])
+    ,(tuple "Silly test" (is-not-equal* 'this-test 'very-silly))])
 
 (defun foreach_test_case (set-up-result)
   "This is called the 'Instantiator' in EUnit parlance."

--- a/test/ltest-fixturecase-tests.lfe
+++ b/test/ltest-fixturecase-tests.lfe
@@ -11,12 +11,12 @@
 (deftestcase setup-tc (set-up-result)
   ;; This is called the 'Instantiator' in EUnit parlance.
   (is-equal set-up-result 'ok)
-  (is-not-equal 'this-test 'very-silly))
+  (tuple "Another named silly one" (is-not-equal 'this-test 'very-silly)))
 
 (deftestcase foreach-tc (set-up-result)
   ;; This is called the 'Instantiator' in EUnit parlance.
   (is-equal set-up-result 'ok)
-  (is-not-equal 'this-test 'very-silly))
+  (tuple "Named silly test" (is-not-equal 'this-test 'very-silly)))
 
 (deftestgen setup-setup `#(setup ,(defsetup set-up) ,(deftestcases setup-tc)))
 

--- a/test/ltest-fixturecase-tests.lfe
+++ b/test/ltest-fixturecase-tests.lfe
@@ -11,12 +11,14 @@
 (deftestcase setup-tc (set-up-result)
   ;; This is called the 'Instantiator' in EUnit parlance.
   (is-equal set-up-result 'ok)
-  (tuple "Another named silly one" (is-not-equal 'this-test 'very-silly)))
+  (is-not-equal 'this-test 'very-silly)
+  (tuple "Named test in setup-tc" (is-not-equal 'good 'evil)))
 
 (deftestcase foreach-tc (set-up-result)
   ;; This is called the 'Instantiator' in EUnit parlance.
   (is-equal set-up-result 'ok)
-  (tuple "Named silly test" (is-not-equal 'this-test 'very-silly)))
+  (is-not-equal 'this-test 'very-silly)
+  (tuple "Named foreach-tc test" (is-not-equal 'people  'things)))
 
 (deftestgen setup-setup `#(setup ,(defsetup set-up) ,(deftestcases setup-tc)))
 


### PR DESCRIPTION

![ltest-scr](https://cloud.githubusercontent.com/assets/8608855/17912343/f0ad438a-6960-11e6-9fd6-fdacc1820b0f.png)
* Shows the user-defined "Name" in reports
* Name is specified with eunit format (tuple "Name" ...<test>...)
* Works with fixtures and deftestcase
* This is better than simply repeating the fixture function name
  for every test
* Does not work for plain deftest because of an eunit bug which
  does not send the name to the listener for plain tests