### PR TITLE
handle cancelled tests

### DIFF
--- a/src/ltest-formatter.lfe
+++ b/src/ltest-formatter.lfe
@@ -166,6 +166,27 @@
   (io:format (ltest-color:yellow (get-no-results-report data state)))
   (finish-section))
 
+(defun display-test-cancel (reason)
+  (io:format (format-cancel reason)))
+
+(defun format-cancel
+  (('undefined)  "*skipped*~n")
+  (('timeout)    "*timed out*~n")
+
+  ((`#(startup ,reason))
+    (io_lib:format "*could not start test process*~n::~tP~n~n"
+                   (list reason 15)))
+
+  ((`#(blame ,_subid))
+    "*cancelled because of subtask*~n")
+
+  ((`#(exit ,reason))
+    (io_lib:format "*unexpected termination of test process*~n::~tP~n~n"
+                   (list reason 15)))
+
+  ((`#(abort ,reason))
+    (eunit_lib:format_error reason)))
+
 (defun get-no-results-report (data state)
   (io_lib:format
     "There were no ~s tests found.~n"

--- a/src/ltest-listener.lfe
+++ b/src/ltest-listener.lfe
@@ -78,7 +78,7 @@
 (defun handle_cancel
   ((_group_or_test data state)
     (ltest-formatter:display-test-cancel (proplists:get_value 'reason data))
-    ;This counts groups and tests together
+    ;;This counts groups and tests together
     (set-state-err state (+ 1 (state-err state)))))
 
 (defun terminate
@@ -87,7 +87,7 @@
     (if (> (ltest-util:all-tests state) 0)
         (ltest-formatter:display-results data state)
         (ltest-formatter:display-no-results data state))
-    ;error out if tests were cancelled
+    ;;error out if tests were cancelled
     (if (> (proplists:get_value 'cancel data 0) 0)
         (io:format (ltest-color:red "One or more tests were cancelled.\n"))
         (sync_end 'error));same behaviour as eunit

--- a/src/ltest-listener.lfe
+++ b/src/ltest-listener.lfe
@@ -76,8 +76,10 @@
     state))
 
 (defun handle_cancel
-  ((_ data state)
-    state))
+  ((_group_or_test data state)
+    (ltest-formatter:display-test-cancel (proplists:get_value 'reason data))
+    ;This counts groups and tests together
+    (set-state-err state (+ 1 (state-err state)))))
 
 (defun terminate
   ((`#(ok ,data) state)
@@ -85,6 +87,10 @@
     (if (> (ltest-util:all-tests state) 0)
         (ltest-formatter:display-results data state)
         (ltest-formatter:display-no-results data state))
+    ;error out if tests were cancelled
+    (if (> (proplists:get_value 'cancel data 0) 0)
+        (io:format (ltest-color:red "One or more tests were cancelled.\n"))
+        (sync_end 'error));same behaviour as eunit
     `#(ok ,data ,state))
   ((`#(error ,reason) state)
     (io:nl)

--- a/test/ltest-cancelled-tests.lfe
+++ b/test/ltest-cancelled-tests.lfe
@@ -1,0 +1,20 @@
+(defmodule ltest-cancel-tests
+  ;Take the number one out of the next line
+  ;and  run make check-runner-ltest
+  ; you should get one errored test and
+  ; a message saying
+  ; "One or more tests were cancelled."
+  (behaviour ltest-unit1))
+
+(include-lib "include/ltest-macros.lfe")
+
+(defun set-up () 'ok)
+
+(defun setup_test_case (set-up-result)
+  "This test causes cancellation because of missing comma."
+  `[ (is-not-equal* 'this-causes-cancellation 'because-of-comma-missing)
+     ,(tuple "Another unused test" (is-not-equal* 'to-be 'or-not-to-be))])
+
+(deftestgen setup-setup
+  `#(setup ,(defsetup set-up) ,#'setup_test_case/1))
+

--- a/test/ltest-cancelled-tests.lfe
+++ b/test/ltest-cancelled-tests.lfe
@@ -1,9 +1,19 @@
 (defmodule ltest-cancel-tests
-  ;Take the number one out of the next line
-  ;and  run make check-runner-ltest
-  ; you should get one errored test and
-  ; a message saying
-  ; "One or more tests were cancelled."
+  "This module is meant to test
+   the ability to recognize cancelled
+   tests (e.g.  fixture tests that
+   have bad contents).
+
+   In order to enable this test, take the
+   number one (1) out of the behaviour name
+   below, and you should see
+   \"One or more tests were cancelled.\" in
+   the runner output.
+
+   It is disabled because normally you want
+   to see the test suite finishing without
+   errors.
+  "
   (behaviour ltest-unit1))
 
 (include-lib "include/ltest-macros.lfe")


### PR DESCRIPTION
This covers cancelled tests, which `eunit` handles but `ltest` was not. It solves some of the problems mentioned in issue #49.

`ltest-listener` was ignoring the **`handle_cancel`** callback, simply returning the state; which is a little dangerous because it can make you think that all the tests passed. This patch solves that problem.

This patch prints the same messages as `eunit`.
 