### PR TITLE
Added the new way to run tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,20 +84,21 @@ listener (test runner).
 ### Adding ltest to Your Project [&#x219F;](#contents)
 
 In order to use ltest in your project, all you need to do is add a rebar dep.
-In your ``rebar.config`` file, simply add an extra line for ``ltest``:
+In your ``rebar.config`` file, simply add an extra line for ``ltest`` and one for where to take your tests from:
 
 ```erlang
 {deps, [
     {lfe, ".*", {git, "git://github.com/rvirding/lfe.git", "master"}},
     {ltest, ".*", {git, "git://github.com/lfex/ltest.git", "master"}}
   ]}.
+
+{eunit_compile_opts, [{src_dirs, ["src", "test"]}]}.
 ```
 
 Once you write some tests (see below for how to do that), you can then do this:
 
 ```bash
-$ lfetool tests build
-$ lfetool tests unit
+$ rebar3 eunit
 ```
 
 


### PR DESCRIPTION
I wasn't sure how to go about changing the other places where `lfetool` is mentioned, but I wanted to make the first one up to date with how ltest is being run through rebar3.

Please let me know if anything else needs changing or I should add this somewhere else entirely.