### PR TITLE
Relax versions of hex.pm dependencies

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,8 +5,8 @@
   ]}.
 
 {deps, [
-   {lfe, "2.1.2"},
-   {erlang_color, "1.0.0"}
+   {lfe, "~> 2.1"},
+   {erlang_color, "~> 1.0"}
   ]}.
 
 {plugins, [


### PR DESCRIPTION
Right now ltest does not work on any project trying to use lfe 2.1.3. Since hex.pm requires semver, and rebar3 supports this, we can relax the required versions listed in the rebar.config. This allows for this library to work with any minor version without requiring a version bump for ltest. For a core library like ltest, I could see the argument being made for either patch versions or minor versions, so feel free to change this or request changes if you prefer the more strict approach.