### PR TITLE
Don't export all from behaviors...

### DIFF
--- a/src/ltest-integration.lfe
+++ b/src/ltest-integration.lfe
@@ -1,5 +1,7 @@
 (defmodule ltest-integration
-  (export all))
+  (export
+   (behaviour_info 1)
+   (get-modules 0)))
 
 (defun behaviour_info
   (('callbacks)

--- a/src/ltest-system.lfe
+++ b/src/ltest-system.lfe
@@ -1,5 +1,7 @@
 (defmodule ltest-system
-  (export all))
+  (export
+   (behaviour_info 1)
+   (get-modules 0)))
 
 (defun behaviour_info
   (('callbacks)

--- a/src/ltest-unit.lfe
+++ b/src/ltest-unit.lfe
@@ -1,5 +1,7 @@
 (defmodule ltest-unit
-  (export all))
+  (export
+   (behaviour_info 1)
+   (get-modules 0)))
 
 (defun behaviour_info
   (('callbacks)


### PR DESCRIPTION
This causes a double export declaration:
one from export-module when using deftest,
another from the behaviour which has a export all.